### PR TITLE
Addding Stale Tag in github bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is labelled as stale because it has been open for more than 7 days with no activity.'
-        days-before-stale: 1
+        days-before-stale: 7
         stale-issue-label: 'Stale'
         exempt-issue-labels: 'Announcement,Pinned'
         remove-stale-when-updated: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "*/30 * * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is labelled as stale because it has been open for more than 7 days with no activity.'
+        days-before-stale: 1
+        stale-issue-label: 'Stale'
+        exempt-issue-labels: 'Announcement,Pinned'
+        remove-stale-when-updated: true


### PR DESCRIPTION
## Related Issuse

- adding stale tag yml file for github action
Closes: #152

#### Describe the changes you've made

I have added a Github Action to mark stale Issues with a Tag. Issues that are not assigned, or have not been mentioned anywhere for more than 7 Days should be tagged with a "Stale" tag automatically.

## Checklist:


- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new error.

## Screenshots
This yml file one of my local directory with "no of days before stale" =1
Sample test issue day 0 (screenshot)
<img width="698" alt="Screenshot 2021-04-05 232220" src="https://user-images.githubusercontent.com/52033949/113768161-28e7a100-973d-11eb-8b6a-ef2346b2d0c8.png">

Sample test issue day 1 (screenshot)
<img width="917" alt="Screenshot 2021-04-06 014615" src="https://user-images.githubusercontent.com/52033949/113768373-66e4c500-973d-11eb-8b5d-364e444913b8.png">


As per requirement of the issue "no of days before stale" =7 for this pr.